### PR TITLE
MBTI + 선호 태그 기반 매칭 점수 로직 개선

### DIFF
--- a/src/main/java/com/example/date_app/dto/MatchRecommendation.java
+++ b/src/main/java/com/example/date_app/dto/MatchRecommendation.java
@@ -11,6 +11,5 @@ public class MatchRecommendation {
     private String email;
     private String name;
     private String mbti;
-    private List<String> commonTags;
     private int score;
 }


### PR DESCRIPTION
### **주요 변경 사항**
- 기존의 공통 태그에 대한 매칭 점수 로직 제거
- `likeTags` 기반 선호도 반영하여 매칭 점수 계산 강화
- Firebase에서 사용자 프로필 조회 시 예외 처리 추가
- 기존 MatchRecommendation DTO에서 `commonTags` 필드 제거
  - 프론트엔드에서 해당 필드를 사용하고 있다면 수정 필요


### **관련된 프론트엔드 영향**
- `commonTags` 참조하는 로직 제거 또는 대체 필요


### **likeTags 가져오는 방식**
- `FirebaseAuthService.getUserProfile(myEmail)`을 통해 해당 사용자의 전체 프로필을 불러옴
- 프로필 내 `personality.likeTags` 항목에서 선호 태그 리스트를 추출
- 추출된 likeTags 리스트와 상대방의 tags 리스트를 비교하여 공통 태그 개수만큼 점수에 추가 반영